### PR TITLE
[FEAT] Album 폴더 내 화면 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         android:name="android.hardware.camera"
         android:required="false" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/android/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/android/navigation/NavGraph.kt
@@ -2,10 +2,15 @@ package com.example.android.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.example.android.ui.album.AlbumDetailScreen
+import com.example.android.ui.album.AlbumPhotoDetailScreen
 import com.example.android.ui.album.AlbumScreen
 import com.example.android.ui.home.HomeScreen
 import com.example.android.ui.profile.ProfileScreen
@@ -38,7 +43,32 @@ fun NavGraph(
         }
 
         composable("home") { HomeScreen() }
-        composable("album") { AlbumScreen() }
+        composable("album") { AlbumScreen(navController) }
         composable("profile") { ProfileScreen() }
+
+        composable(
+            route = "albumDetail/{albumName}",
+            arguments = listOf(navArgument("albumName") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val albumName = backStackEntry.arguments?.getString("albumName") ?: ""
+            AlbumDetailScreen(navController, albumName)
+        }
+
+        composable(
+            "photoDetail/{albumName}/{photoName}",
+            arguments = listOf(
+                navArgument("albumName") { type = NavType.StringType },
+                navArgument("photoName") { type = NavType.StringType }
+            )
+        ) { backStackEntry ->
+            val context = LocalContext.current
+            val albumName = backStackEntry.arguments?.getString("albumName")!!
+            val photoName = backStackEntry.arguments?.getString("photoName")!!
+
+            AlbumPhotoDetailScreen(
+                albumName = albumName,
+                photoName = photoName
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/android/ui/album/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/example/android/ui/album/AlbumDetailScreen.kt
@@ -1,0 +1,110 @@
+package com.example.android.ui.album
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import coil.compose.rememberAsyncImagePainter
+import com.example.android.R
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun AlbumDetailScreen(navController: NavController, albumName: String) {
+    val context = LocalContext.current
+    val photos = remember { mutableStateOf<List<File>>(emptyList()) }
+    val albumDir = File(context.filesDir, "four-togenic/$albumName")
+
+    // 폴더 정보 추출
+    val createdAt = remember {
+        // 생성일은 기본적으로 접근 불가이므로 폴더의 첫 파일의 생성일, 아니면 lastModified 대안 사용
+        val files = albumDir.listFiles { file -> file.isFile }
+        files?.minByOrNull { it.lastModified() }?.lastModified() ?: albumDir.lastModified()
+    }
+    val lastUpdated = albumDir.lastModified()
+
+    // 날짜 포맷
+    val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+    val createdAtStr = dateFormat.format(Date(createdAt))
+    val lastUpdatedStr = dateFormat.format(Date(lastUpdated))
+
+    LaunchedEffect(Unit) {
+        photos.value = albumDir.listFiles { file -> file.isFile }?.toList() ?: emptyList()
+    }
+
+    Column (
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        // 상단 앨범 정보
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_album),
+                contentDescription = "Album Icon",
+                tint = Color(0xFF90A4AE),
+                modifier = Modifier.size(84.dp).padding(end = 16.dp)
+            )
+            Column {
+                Text("Album Name: $albumName", fontWeight = FontWeight.Bold)
+                Text("Created At: $createdAtStr")
+                Text("Last Updated: $lastUpdatedStr")
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (photos.value.isEmpty()) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("사진이 없습니다.")
+            }
+        } else {
+            LazyVerticalGrid(columns = GridCells.Fixed(2)) {
+                items(photos.value) { photo ->
+                    Image(
+                        painter = rememberAsyncImagePainter(photo),
+                        contentDescription = photo.name,
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .aspectRatio(1f)
+                            .clip(RoundedCornerShape(4.dp))
+                            .clickable {
+                                // NavController를 통해 AlbumPhotoDetailScreen으로 이동
+                                navController.navigate("photoDetail/${albumName}/${photo.name}")
+                            },
+                        contentScale = ContentScale.Crop
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/android/ui/album/AlbumPhotoDetailScreen.kt
+++ b/app/src/main/java/com/example/android/ui/album/AlbumPhotoDetailScreen.kt
@@ -1,0 +1,120 @@
+package com.example.android.ui.album
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.example.android.R
+import java.io.File
+
+@Composable
+fun AlbumPhotoDetailScreen(albumName: String, photoName: String) {
+    val context = LocalContext.current
+    val albumDir = File(context.filesDir, "four-togenic/$albumName")
+    val memo = remember { mutableStateOf("") }
+
+    // 사진 파일 경로
+    val photoFile = File(context.filesDir, "four-togenic/$albumName/$photoName")
+    val createdAt = remember {
+        // 생성일은 기본적으로 접근 불가이므로 폴더의 첫 파일의 생성일, 아니면 lastModified 대안 사용
+        val files = albumDir.listFiles { file -> file.isFile }
+        files?.minByOrNull { it.lastModified() }?.lastModified() ?: albumDir.lastModified()
+    }
+    val lastUpdated = File(photoFile.path).lastModified()
+
+    // 날짜 포맷
+    val dateFormat = java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.getDefault())
+    val createdAtStr = dateFormat.format(java.util.Date(createdAt))
+    val lastUpdatedStr = dateFormat.format(java.util.Date(lastUpdated))
+
+    // 메모 불러오기 (텍스트 파일이 있다면)
+    LaunchedEffect(photoFile) {
+        val memoFile = File(context.filesDir, "four-togenic/$albumName/${photoName}.txt")
+        if (memoFile.exists()) {
+            memo.value = memoFile.readText()
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        // 상단 앨범 정보
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_album),
+                contentDescription = "Album Icon",
+                tint = Color(0xFF90A4AE),
+                modifier = Modifier.size(84.dp).padding(end = 16.dp)
+            )
+            Column {
+                Text("Album Name: $albumName", fontWeight = FontWeight.Bold)
+                Text("Created At: $createdAtStr")
+                Text("Last Updated: $lastUpdatedStr")
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+        // 사진 크게 표시
+        Image(
+            painter = rememberAsyncImagePainter(photoFile),
+            contentDescription = photoFile.name,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(8.dp)),
+            contentScale = ContentScale.Crop
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // 메모 입력
+        TextField(
+            value = memo.value,
+            onValueChange = { memo.value = it },
+            placeholder = { Text("Enter a memo") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(90.dp)
+        )
+
+        // 저장 버튼
+        Button(
+            onClick = {
+                val memoFile = File(context.filesDir, "four-togenic/$albumName/${photoName}.txt")
+                memoFile.writeText(memo.value)
+            },
+            modifier = Modifier
+                .padding(top = 16.dp)
+                .height(40.dp) // 높이를 낮게 설정
+        ) {
+            Text("Save", modifier = Modifier.padding(vertical = 0.dp)) // 텍스트 패딩 제거
+        }
+    }
+}

--- a/app/src/main/java/com/example/android/ui/album/AlbumScreen.kt
+++ b/app/src/main/java/com/example/android/ui/album/AlbumScreen.kt
@@ -1,18 +1,162 @@
 package com.example.android.ui.album
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import android.content.Context
+import android.provider.MediaStore
+import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import coil.compose.rememberAsyncImagePainter
+import com.example.android.R
+import com.example.android.getAlbumsRootDir
+import java.io.File
+
+data class Album(
+    val name: String
+)
 
 @Composable
-fun AlbumScreen() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(text = "Album Screen")
+fun AlbumScreen(navController: NavController) {
+    val context = LocalContext.current
+    var albums by remember { mutableStateOf<List<Album>>(emptyList()) }
+    var showDialog by remember { mutableStateOf(false) }
+    var albumName by remember { mutableStateOf("") }
+
+    LaunchedEffect(Unit) {
+        albums = loadAlbums(context)
+    }
+
+    // "앨범 추가" 버튼을 위해 기존 앨범 + 가짜 항목 하나 더
+    val albumsWithAddButton = albums + Album("AddButton")
+
+    LazyVerticalGrid(columns = GridCells.Fixed(2)) {
+        items(albumsWithAddButton) { album ->
+            if (album.name == "AddButton") {
+                // 마지막 "앨범 추가" 버튼
+                Box(
+                    modifier = Modifier
+                        .padding(8.dp)
+                        .aspectRatio(1f)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Color.LightGray)
+                        .clickable {
+                            showDialog = true
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Add,
+                        contentDescription = "앨범 추가",
+                        modifier = Modifier.size(48.dp),
+                        tint = Color.DarkGray
+                    )
+                }
+
+                if (showDialog) {
+                    AlertDialog(
+                        onDismissRequest = { showDialog = false },
+                        title = { Text(text = "Enter Album Name") },
+                        text = {
+                            TextField(
+                                value = albumName,
+                                onValueChange = { albumName = it },
+                                label = { Text("Album Name") }
+                            )
+                        },
+                        confirmButton = {
+                            Button (onClick = {
+                                createAlbumFolder(context, albumName)
+                                albums = loadAlbums(context)
+                                showDialog = false
+                                albumName = ""
+                            }) {
+                                Text("Save")
+                            }
+                        },
+                        dismissButton = {
+                            Button(onClick = {
+                                showDialog = false
+                            }) {
+                                Text("Cancel")
+                            }
+                        }
+                    )
+                }
+            } else {
+                // 일반 앨범 항목
+                Column(
+                    modifier = Modifier
+                        .padding(8.dp)
+                        .clickable {
+                            navController.navigate("albumDetail/${album.name}")
+                        }
+                ) {
+                    Image(
+                        painter = rememberAsyncImagePainter(R.drawable.ic_album), // 네가 정한 이미지 리소스
+                        contentDescription = album.name,
+                        modifier = Modifier
+                            .aspectRatio(1f)
+                            .clip(RoundedCornerShape(8.dp)),
+                        contentScale = ContentScale.Crop
+                    )
+
+                    Text(
+                        text = album.name,
+                        modifier = Modifier.padding(top = 4.dp),
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+        }
+    }
+}
+
+// MediaStore에서 폴더(앨범) 이름만 가져오기
+fun loadAlbums(context: Context): List<Album> {
+    val rootDir = getAlbumsRootDir(context)
+    val folders = rootDir.listFiles { file -> file.isDirectory } ?: arrayOf()
+    return folders.map { Album(it.name) }
+}
+
+fun createAlbumFolder(context: Context, albumName: String) {
+    if (albumName.isBlank()) return
+
+    val rootDir = getAlbumsRootDir(context)
+    val newAlbum = File(rootDir, albumName)
+
+    if (!newAlbum.exists()) {
+        val created = newAlbum.mkdirs()
+        if (created) {
+            Toast.makeText(context, "앨범 생성 완료!", Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(context, "앨범 생성 실패", Toast.LENGTH_SHORT).show()
+        }
+    } else {
+        Toast.makeText(context, "이미 존재하는 앨범 이름입니다", Toast.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/java/com/example/android/ui/components/TopBar.kt
+++ b/app/src/main/java/com/example/android/ui/components/TopBar.kt
@@ -4,25 +4,33 @@ import android.content.Intent
 import android.provider.MediaStore
 import android.widget.Toast
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.CameraAlt
-import androidx.compose.material.icons.filled.Face
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
-import com.example.android.R
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TopBar(title: String, onCameraClick: () -> Unit) {
+fun TopBar(
+    title: String,
+    onCameraClick: () -> Unit,
+    showBackButton: Boolean = false,
+    onBackClick: (() -> Unit)? = null
+) {
     CenterAlignedTopAppBar(
         title = { Text(text = title) },
-        modifier = androidx.compose.ui.Modifier,
+        navigationIcon = {
+            if (showBackButton && onBackClick != null) {
+                IconButton(onClick = onBackClick) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = "뒤로가기"
+                    )
+                }
+            }
+        },
         colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
             containerColor = Color(0xFFCBDCEB)
         ),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #7

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

- 앨범 화면에 앨범들 표시 및 앨범 추가 버튼 추가
- 앨범 클릭하면 앨범 안에 있는 사진들 추가
- 앨범 클릭시에 뒤로가기 버튼 구현

---

## ✅ 변경 사항 체크리스트

다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등)
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등)
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료)

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

<img width="632" height="1374" alt="image" src="https://github.com/user-attachments/assets/2b1f8974-e72e-4b81-bb3d-6cb9bea31a60" />

**+ 버튼 누르면 나오는 창**
<img width="504" height="378" alt="image" src="https://github.com/user-attachments/assets/ede21c7d-5e14-4ee4-bed0-05614f9acae1" />

<img width="612" height="1324" alt="image" src="https://github.com/user-attachments/assets/d35e21e8-b2c2-4a04-bf69-dbc793482730" />

<img width="616" height="1234" alt="image" src="https://github.com/user-attachments/assets/e2e1f8cf-da08-4b22-8304-013223b39301" />

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 현재 앱 내부에 four-togenic 라는 폴더를 만들어서 여기에 있는 폴더들을 앨범으로 띄우는 거고, 그 폴더 안에 있는 사진들을 띄우는 구조로 되어있습니다. four-togenic 이폴더는 앱 실행시 자동으로 생성되게 되어있습니다.

- 뒤로가기 버튼은 AlbumPhotoDetail, AlbumDetail 에만 걸려있고, 나중에 뒤로가기 버튼을 특정화면에 추가하고 싶으시다면 MainActivitiy에
_showBackButton = currentRoute?.startsWith("albumDetail") == true ||
                                        currentRoute?.startsWith("photoDetail") == true,_
이 부분만을 건들면 됩니다.

- 현재 내부 갤러리에서 사진을 땡겨오는게 아니라 앱 자체에 사진을 저장해두고 불러오는 방식으로 구현하였습니다.
  (앱 내부 갤러리에서 땡겨오게 하고 싶긴했는데 조금 많이 어려워서 일단은 이렇게 구현해두었습니다.)

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.